### PR TITLE
Do not run go-mod-verify during gotip workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,6 +48,7 @@ jobs:
       run: go version
 
     - name: Verify go mod
+      if: matrix.go != 'tip'
       run: make verify-go-mod
       working-directory: ${{ github.workspace }}/go/src/${{ github.repository }}
 


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>